### PR TITLE
Add spec for LDAP validator

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/ldap/EditLdapCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/ldap/EditLdapCommand.java
@@ -17,10 +17,13 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.ldap;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.converters.URIConverter;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.AbstractEditAuthnMethodCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Ldap;
 import lombok.Getter;
+
+import java.net.URI;
 
 public class EditLdapCommand extends AbstractEditAuthnMethodCommand<Ldap> {
 
@@ -35,9 +38,10 @@ public class EditLdapCommand extends AbstractEditAuthnMethodCommand<Ldap> {
 
   @Parameter(
       names = "--url",
-      description = "ldap:// or ldaps:// url of the LDAP server"
+      description = "ldap:// or ldaps:// url of the LDAP server",
+      converter = URIConverter.class
   )
-  private String url;
+  private URI url;
 
   @Parameter(
       names = "--user-dn-pattern",

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Ldap.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Ldap.java
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.net.URI;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class Ldap extends AuthnMethod{
@@ -28,7 +30,7 @@ public class Ldap extends AuthnMethod{
   private final Method method = Method.LDAP;
   private final String nodeName = "ldap";
 
-  private String url;
+  private URI url;
   private String userDnPattern;
   private String userSearchBase;
   private String userSearchFilter;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidator.java
@@ -32,8 +32,10 @@ public class LdapValidator extends Validator<Ldap> {
       return;
     }
 
-    if (StringUtils.isEmpty(ldap.getUrl())) {
-      p.addProblem(Problem.Severity.ERROR, "LDAP url must be provided.");
+    if (ldap.getUrl() == null) {
+      p.addProblem(Problem.Severity.ERROR, "LDAP url missing.");
+    } else if (! ldap.getUrl().getScheme().equalsIgnoreCase("ldaps") && ! ldap.getUrl().getScheme().equalsIgnoreCase("ldap")) {
+      p.addProblem(Problem.Severity.ERROR, "LDAP url must use ldap or ldaps protocol.");
     }
 
     if(StringUtils.isEmpty(ldap.getUserDnPattern())) {

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
@@ -20,7 +20,8 @@ class LdapValidatorSpec extends Specification {
   @Unroll
   void "valid case: #description"() {
     setup:
-    def ldap = new Ldap(url: ldapUrl, userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    def ldap = new Ldap(userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    ldap.url = ldapUrl ? new URI(ldapUrl) : null
     ldap.enabled = enabled
 
     when:
@@ -35,12 +36,14 @@ class LdapValidatorSpec extends Specification {
     "not enabled"             | false   | null                      | null           | null           | null
     "minimal set"             | true    | "ldaps://ldap.some.com"   | "some pattern" | null           | null
     "all properties set"      | true    | "ldaps://ldap.some.com"   | "some pattern" | "sub"          | "ou=foo"
+    "plain LDAP"              | true    | "ldap://ldap.some.com"    | "some pattern" | "sub"          | "ou=foo"
   }
 
   @Unroll
   void "invalid case: #description"() {
     setup:
-    def ldap = new Ldap(url: ldapUrl, userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    def ldap = new Ldap(userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    ldap.url = ldapUrl ? new URI(ldapUrl) : null
     ldap.enabled = true
 
     when:
@@ -59,11 +62,8 @@ class LdapValidatorSpec extends Specification {
     "missing ldap url"        | null                      | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
 // coming soon:
 //    "invalid url"             | "not a real url"          | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
-//    "wrong url protocol"      | "https://ldap.some.com"   | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
+    "wrong url protocol"      | "https://ldap.some.com"   | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
     "search base empty"       | "ldaps://ldap.some.com"   | "some pattern" | ""             | "ou=foo"         || "ldap user search base"
     "search filter empty"     | "ldaps://ldap.some.com"   | "some pattern" | "sub"          | ""               || "ldap user search filter"
   }
 }
-
-
-

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
@@ -1,0 +1,66 @@
+package com.netflix.spinnaker.halyard.config.validate.v1.security
+
+import com.netflix.spinnaker.halyard.config.model.v1.security.Ldap
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LdapValidatorSpec extends Specification {
+
+  LdapValidator validator
+  ConfigProblemSetBuilder problemSetBuilder
+
+  void setup() {
+    problemSetBuilder = new ConfigProblemSetBuilder()
+    validator = new LdapValidator()
+  }
+
+  @Unroll
+  void "valid case: #description"() {
+    setup:
+    def ldap = new Ldap(url: ldapUrl, userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    ldap.enabled = enabled
+
+    when:
+    validator.validate(problemSetBuilder, ldap)
+    ProblemSet problemSet = problemSetBuilder.build()
+
+    then:
+    problemSet.empty
+
+    where:
+    description               | enabled | ldapUrl                   | userDnPattern  | userSearchBase | userSearchFilter
+    "not enabled"             | false   | null                      | null           | null           | null
+    "minimal set"             | true    | "ldaps://ldap.target.com" | "some pattern" | null           | null
+    "all properties set"      | true    | "ldaps://ldap.target.com" | "some pattern" | "sub"          | "ou=foo"
+  }
+
+  @Unroll
+  void "invalid case: #description"() {
+    setup:
+    def ldap = new Ldap(url: ldapUrl, userDnPattern: userDnPattern, userSearchBase: userSearchBase, userSearchFilter: userSearchFilter)
+    ldap.enabled = true
+
+    when:
+    validator.validate(problemSetBuilder, ldap)
+    ProblemSet problemSet = problemSetBuilder.build()
+
+    then:
+    ! problemSet.empty
+    problemSet.problems.size() == 1
+    problemSet.problems[0].severity == Problem.Severity.ERROR
+    problemSet.problems[0].message.toLowerCase().contains(errorMessageMatches)
+
+    where:
+    description               | ldapUrl                   | userDnPattern  | userSearchBase | userSearchFilter || errorMessageMatches
+    "missing user dn pattern" | "ldaps://ldap.target.com" | null           | "sub"          | "ou=foo"         || "user dn pattern"
+    "missing ldap url"        | null                      | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
+    "search base empty"       | "ldaps://ldap.target.com" | "some pattern" | ""             | "ou=foo"         || "ldap user search base"
+    "search filter empty"     | "ldaps://ldap.target.com" | "some pattern" | "sub"          | ""               || "ldap user search filter"
+  }
+}
+
+
+

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
@@ -33,8 +33,8 @@ class LdapValidatorSpec extends Specification {
     where:
     description               | enabled | ldapUrl                   | userDnPattern  | userSearchBase | userSearchFilter
     "not enabled"             | false   | null                      | null           | null           | null
-    "minimal set"             | true    | "ldaps://ldap.target.com" | "some pattern" | null           | null
-    "all properties set"      | true    | "ldaps://ldap.target.com" | "some pattern" | "sub"          | "ou=foo"
+    "minimal set"             | true    | "ldaps://ldap.some.com"   | "some pattern" | null           | null
+    "all properties set"      | true    | "ldaps://ldap.some.com"   | "some pattern" | "sub"          | "ou=foo"
   }
 
   @Unroll
@@ -55,10 +55,13 @@ class LdapValidatorSpec extends Specification {
 
     where:
     description               | ldapUrl                   | userDnPattern  | userSearchBase | userSearchFilter || errorMessageMatches
-    "missing user dn pattern" | "ldaps://ldap.target.com" | null           | "sub"          | "ou=foo"         || "user dn pattern"
+    "missing user dn pattern" | "ldaps://ldap.some.com"   | null           | "sub"          | "ou=foo"         || "user dn pattern"
     "missing ldap url"        | null                      | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
-    "search base empty"       | "ldaps://ldap.target.com" | "some pattern" | ""             | "ou=foo"         || "ldap user search base"
-    "search filter empty"     | "ldaps://ldap.target.com" | "some pattern" | "sub"          | ""               || "ldap user search filter"
+// coming soon:
+//    "invalid url"             | "not a real url"          | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
+//    "wrong url protocol"      | "https://ldap.some.com"   | "some pattern" | "sub"          | "ou=foo"         || "ldap url"
+    "search base empty"       | "ldaps://ldap.some.com"   | "some pattern" | ""             | "ou=foo"         || "ldap user search base"
+    "search filter empty"     | "ldaps://ldap.some.com"   | "some pattern" | "sub"          | ""               || "ldap user search filter"
   }
 }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/LdapConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/LdapConfig.java
@@ -21,12 +21,14 @@ import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.net.URI;
+
 @EqualsAndHashCode(callSuper = false)
 @Data
 public class LdapConfig {
   boolean enabled;
 
-  String url;
+  URI url;
   String userDnPattern;
   String userSearchBase;
   String userSearchFilter;


### PR DESCRIPTION
I wasn't around to help actually test-drive these changes so far, but here's a little back-filled spec to show one way we might have done it.

Also included: two commented-out lines which we could use to test-drive the URL validations mentioned in @loomisdf's PR.